### PR TITLE
Update memoryless_excursions.tex

### DIFF
--- a/memoryless_excursions.tex
+++ b/memoryless_excursions.tex
@@ -569,10 +569,12 @@ Taking partial derivatives,
 f_{L,M}(x,y) 
 &=\partial_x\partial_{y}F_{L,M}(x,y) \\  
 &=\partial_x\partial_{y}2 F_{X}(x) (F_Y(y)-F_Y(x)) \1{y>x}\\
-&=2 \partial_x F_{X}(x) \partial_{y} (F_Y(y)-F_Y(x)) \1 {y>x} \\
-&= 2f_X(x) f_Y(y)\1{y>x} \\ 
+&=2 \partial_x \left( F_{X}(x) \partial_{y} (F_Y(y)-F_Y(x))  \1 {y>x} \right) \\
+&=2 \partial_x \left( F_{X}(x) f_Y(y)  \1 {y>x} \right)\\
+&= 2f_X(x) f_Y(y)\1{y>x} 
 \end{align}
-Why could I remove the 2?
+
+Note that $\partial_x$ means the same as $\frac{\partial}{\partial x}$.
 
 Now,
 \begin{align}
@@ -582,7 +584,7 @@ Now,
 &= 2 f_Y(y) \int_0^{y} f_{X}(x) \d x  \\
 &= 2f_Y(y) F_X(y), \\
 f_L(x) &=  \int_0^{\infty} f_{L,M}(x,y) \d y \\
-&= 2 f_{X}(x) \int_x^{\infty} f_Y(y) \d x \\
+&= 2 f_{X}(x) \int_x^{\infty} f_Y(y) \d y \\
 &= 2 f_{X}(x) (1-F_Y(x)).
 \end{align}
 


### PR DESCRIPTION
Added a step in this exercise, because it is important to realize that the we cannot just break up this double partial derivative as a product of two partial derivatives (since F_Y(x) depends on x). Added a remark on the notation (which has not been used before, I think,)

Additional suggestion: it might be nice to explicitly check that these densities integrate to 1, possibly creating a new exercise for this.